### PR TITLE
Update `aliquot` to new version 2.1.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,11 +17,36 @@ a.process
 
 ## Unit tests ##
 
-To be sure that unit tests run properly, you can run them in a docker container.
+To be sure that unit tests run properly, you can run them in a Docker container.
 
 ```bash
 docker run -ti --rm -v $(pwd):/opt/aliquot ruby:2.7.4 bash
 cd /opt/aliquot
 bundle install
 bundle exec rspec
+exit
 ```
+
+## Publishing new Gem
+
+Beware of cyclic dependency with `aliquot-pay`. Update the new versions 
+for these gems in parallel.
+
+1. Update [./aliquot.gemspec](./aliquot.gemspec)
+    ```gemspec
+    Gem::Specification.new do |s|
+      s.name     = 'aliquot'
+      s.version  = '${NEW_ALIQUOT_VERSION}'
+      ...
+      s.add_development_dependency 'aliquot-pay', '~> ${NEW_ALIQUOT-PAY_VERSION}'
+      ...
+    end
+    ```
+
+2. Run the following
+    ```bash
+    gem build
+    gem push aliquot-${NEW_ALIQUOT_VERSION}.gem
+    ```
+
+3. Then do the same for `aliquot-pay` if not already done.

--- a/aliquot.gemspec
+++ b/aliquot.gemspec
@@ -3,7 +3,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |s|
   s.name     = 'aliquot'
-  s.version  = '2.1.0'
+  s.version  = '2.1.1'
   s.author   = 'Clearhaus'
   s.email    = 'hello@clearhaus.com'
   s.summary  = 'Validates Google Pay tokens'
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'excon',          '~> 0.71.0'
   s.add_runtime_dependency 'hkdf',           '~> 0.3'
 
-  s.add_development_dependency 'aliquot-pay', '~> 2.1.0'
+  s.add_development_dependency 'aliquot-pay', '~> 2.1.1'
   s.add_development_dependency 'rspec',       '~> 3'
-  s.add_development_dependency 'pry'
+  s.add_development_dependency 'pry',         '~> 0.14.1'
 end


### PR DESCRIPTION
Update `README.md` with description on how to push gems with cyclic dependency to rubygems.org.