### PR TITLE
Updated `Payment.decrypt` to set `key` after call to `decrypt` on `cipher`.

### DIFF
--- a/aliquot.gemspec
+++ b/aliquot.gemspec
@@ -3,7 +3,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |s|
   s.name     = 'aliquot'
-  s.version  = '2.1.1'
+  s.version  = '2.1.2'
   s.author   = 'Clearhaus'
   s.email    = 'hello@clearhaus.com'
   s.summary  = 'Validates Google Pay tokens'

--- a/lib/aliquot/payment.rb
+++ b/lib/aliquot/payment.rb
@@ -210,8 +210,8 @@ module Aliquot
 
     def decrypt(key, encrypted)
       c = new_cipher
-      c.key = key
       c.decrypt
+      c.key = key
 
       c.update(Base64.strict_decode64(encrypted)) + c.final
     end


### PR DESCRIPTION
Something must have changed between ruby `2.5.5` and `2.7.4`.