### PR TITLE
Add `gatewayMerchantId`

### DIFF
--- a/lib/aliquot/validator.rb
+++ b/lib/aliquot/validator.rb
@@ -209,6 +209,7 @@ module Aliquot
         required(:messageId).filled(:str?)
         required(:paymentMethod).filled(:str?)
         required(:paymentMethodDetails).filled(:hash).schema(PaymentMethodDetailsContract.schema)
+        optional(:gatewayMerchantId).filled(:str?)
       end
       rule(:messageExpiration).validate(:integer_string?)
       rule(:paymentMethod) do


### PR DESCRIPTION
This PR relates to this issue: https://github.com/clearhaus/aliquot/issues/20

Google Pay docs demand that integrators verify the `gatewayMerchantId` value in the Encrypted Message payload.

The current implementation of Aliquot strips away this crucial parameter since it isn't defined in `Aliquot::Validator::EncryptedMessageContract`.

This PR aims to resolve this by adding this parameter to the Encrypted Message schema so it doesn't get removed and can be checked by the users of this library.
