### PR TITLE
Allow Ruby 3.0.x

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
           ruby-version: ${{ matrix.version }}
 
       - name: Check out repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Install Gems
         run: bundle install

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,8 +10,8 @@ jobs:
         version:
           # - 2.3 # Debian Stretch
           # - 2.5 # Debian Buster
-           - 2.7 # Debian Bullseye
-          # - 3.0 # Debian Bookworm
+          - 2.7 # Debian Bullseye
+          - 3.0 # Debian Bookworm
     steps:
       - uses: ruby/setup-ruby@v1
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,10 +8,10 @@ jobs:
     strategy:
       matrix:
         version:
-          # - 2.3 # Debian Stretch
-          # - 2.5 # Debian Buster
-          - 2.7 # Debian Bullseye
-          - 3.0 # Debian Bookworm
+          # - '2.3' # Debian Stretch
+          # - '2.5' # Debian Buster
+          - '2.7' # Debian Bullseye
+          - '3.0' # Debian Bookworm
     steps:
       - uses: ruby/setup-ruby@v1
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,10 +8,8 @@ jobs:
     strategy:
       matrix:
         version:
-          # - '2.3' # Debian Stretch
-          # - '2.5' # Debian Buster
-          - '2.7' # Debian Bullseye
-          - '3.0' # Debian Bookworm
+          - '2.7'
+          - '3.0'
     steps:
       - uses: ruby/setup-ruby@v1
         with:

--- a/aliquot.gemspec
+++ b/aliquot.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
 
   s.files = Dir.glob('lib/**/*.rb')
 
-  s.required_ruby_version = '~> 2.7'
+  s.required_ruby_version = '>= 2.7', '< 3.1'
 
   s.add_runtime_dependency 'dry-validation', '~> 1.8'
   s.add_runtime_dependency 'excon',          '~> 0.71.0'


### PR DESCRIPTION
I've checked and all tests pass on Ruby 3.0.5.
Currently the gem can only be installed on Ruby 2.7.x, which is extremely restrictive.

I've changed the required Ruby version to include 3.0, since it appears to work.
I've also updated the GitHub workflow so that tests are run on Ruby 2.7 and 3.0.