### PR TITLE
Remove Ruby version upper bound

### DIFF
--- a/aliquot.gemspec
+++ b/aliquot.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
 
   s.files = Dir.glob('lib/**/*.rb')
 
-  s.required_ruby_version = '>= 2.7', '< 3.1'
+  s.required_ruby_version = '>= 2.7'
 
   s.add_runtime_dependency 'dry-validation', '~> 1.8'
   s.add_runtime_dependency 'excon',          '~> 0.71.0'


### PR DESCRIPTION
Hi, I've noticed that `aliquot` works fine on Ruby 3.1 and 3.2.
Tests fail though, because as of now `aliquot-pay` doesn't support Ruby >3.0.

This PR is necessary for [another PR](https://github.com/clearhaus/aliquot-pay/pull/9) in `aliquot-pay` which adds support for Ruby 3.1 and 3.2.