### PR TITLE
Update aliquot-pay to version 2.1.2

### DIFF
--- a/aliquot.gemspec
+++ b/aliquot.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'excon',          '~> 0.71.0'
   s.add_runtime_dependency 'hkdf',           '~> 0.3'
 
-  s.add_development_dependency 'aliquot-pay', '~> 2.1.1'
+  s.add_development_dependency 'aliquot-pay', '~> 2.1.2'
   s.add_development_dependency 'rspec',       '~> 3'
   s.add_development_dependency 'pry',         '~> 0.14.1'
 end

--- a/aliquot.gemspec
+++ b/aliquot.gemspec
@@ -3,7 +3,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |s|
   s.name     = 'aliquot'
-  s.version  = '2.1.3'
+  s.version  = '2.1.4'
   s.author   = 'Clearhaus'
   s.email    = 'hello@clearhaus.com'
   s.summary  = 'Validates Google Pay tokens'


### PR DESCRIPTION
Because of circular dependencies we need to update to a version that does not exists yet