### PR TITLE
Ensure that `aliquot` works on Ruby 3.1

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,6 +10,8 @@ jobs:
         version:
           - '2.7'
           - '3.0'
+          - '3.1'
+          - '3.2'
     steps:
       - uses: ruby/setup-ruby@v1
         with:

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,3 @@
 source 'https://rubygems.org'
 
-gem 'aliquot-pay', git: 'https://github.com/clearhaus/aliquot-pay', branch: 'migrate-to-ruby-3.1'
-
 gemspec

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
 source 'https://rubygems.org'
 
+gem 'aliquot-pay', git: 'https://github.com/clearhaus/aliquot-pay', branch: 'migrate-to-ruby-3.1'
+
 gemspec

--- a/aliquot.gemspec
+++ b/aliquot.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'excon',          '~> 0.71.0'
   s.add_runtime_dependency 'hkdf',           '~> 0.3'
 
-  s.add_development_dependency 'aliquot-pay', '~> 2.1'
-  s.add_development_dependency 'rspec',       '~> 3'
-  s.add_development_dependency 'pry',         '~> 0.14.1'
+  # s.add_development_dependency 'aliquot-pay', '~> 2.1'
+  s.add_development_dependency 'rspec'
+  s.add_development_dependency 'pry'
 end

--- a/aliquot.gemspec
+++ b/aliquot.gemspec
@@ -3,7 +3,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |s|
   s.name     = 'aliquot'
-  s.version  = '2.2.0'
+  s.version  = '2.3.0'
   s.author   = 'Clearhaus'
   s.email    = 'hello@clearhaus.com'
   s.summary  = 'Validates Google Pay tokens'
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'excon',          '~> 0.71.0'
   s.add_runtime_dependency 'hkdf',           '~> 0.3'
 
-  # s.add_development_dependency 'aliquot-pay', '~> 2.1'
-  s.add_development_dependency 'rspec'
-  s.add_development_dependency 'pry'
+  s.add_development_dependency 'aliquot-pay', '~> 3.0'
+  s.add_development_dependency 'rspec',       '~> 3'
+  s.add_development_dependency 'pry',         '~> 0.14.1'
 end

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -9,7 +9,7 @@ shared_examples 'common integration tests' do
       e = StandardError.new('stub method')
       allow(Aliquot::Validator::Token).to receive(:new).and_raise(e)
 
-      is_expected.to raise_error(e)
+      expect { subject.call }.to raise_error(e)
 
       expect(Aliquot::Validator::Token).to have_received(:new).with(token)
     end
@@ -18,7 +18,7 @@ shared_examples 'common integration tests' do
       e = StandardError.new('stub method')
       allow(Aliquot::Validator::SignedMessage).to receive(:new).and_raise(e)
 
-      is_expected.to raise_error(e)
+      expect { subject.call }.to raise_error(e)
 
       expect(Aliquot::Validator::SignedMessage).to have_received(:new).with(generator.build_signed_message)
     end
@@ -27,7 +27,7 @@ shared_examples 'common integration tests' do
       e = StandardError.new('stub method')
       allow(Aliquot::Validator::EncryptedMessageValidator).to receive(:new).and_raise(e)
 
-      is_expected.to raise_error(e)
+      expect { subject.call }.to raise_error(e)
 
       expect(Aliquot::Validator::EncryptedMessageValidator).to have_received(:new).with(generator.build_cleartext_message)
     end
@@ -61,7 +61,7 @@ describe Aliquot::Payment do
       e = StandardError.new('stub method')
       allow(Aliquot::Validator::SignedKeyValidator).to receive(:new).and_raise(e)
 
-      is_expected.to raise_error(e)
+      expect { subject.call }.to raise_error(e)
 
       expect(Aliquot::Validator::SignedKeyValidator).to have_received(:new).with(generator.build_signed_key)
     end


### PR DESCRIPTION
As part of https://github.com/clearhaus/issues-pci/issues/3830

This is updated to use the new version of `aliquot-pay` from PR https://github.com/clearhaus/aliquot-pay/pull/12

- I've utilized the option to install gem from `git`
- I've updated specs such that they do not throw warnings
- I've updated the GitHub action to test for more Ruby versions including 3.1 and 3.2