### PR TITLE
Fix formatting of validation errors

### DIFF
--- a/lib/aliquot/validator.rb
+++ b/lib/aliquot/validator.rb
@@ -226,7 +226,7 @@ module Aliquot
         @validation ||= @schema.call(@input)
         @output = @validation.to_h
         return true if @validation.success?
-        raise Aliquot::ValidationError, "validation error(s), #{errors_formatted}"
+        raise Aliquot::ValidationError, "validation error(s): #{error_list.join(', ')}"
       end
 
       def valid?
@@ -241,13 +241,12 @@ module Aliquot
         @validation.errors
       end
 
-      def errors_formatted(node = [errors])
-        node.pop.flat_map do |key, value|
-          if value.is_a?(Array)
-            value.map { |error| "#{(node + [key]).join('.')} #{error}" }
-          else
-            errors_formatted(node + [key, value])
-          end
+      def error_list(node = errors.to_h, path = '')
+        if node.is_a?(Array)
+          node.map { |error| "#{path} #{error}" }
+        elsif node.is_a?(Hash)
+          path = "#{path}." unless path.empty?
+          node.flat_map { |key, sub_node| error_list(sub_node, "#{path}#{key}") }
         end
       end
     end


### PR DESCRIPTION
Before we would get `NoMethodError: undefined method 'flat_map' for nil:NilClass` if validation failed:

```ruby
From: /var/lib/gems/2.7.0/gems/aliquot-2.1.4/lib/aliquot/validator.rb:232 Aliquot::Validator::InstanceMethods#validate:

    228: def validate
    229:   @validation ||= @schema.call(@input)
    230:   @output = @validation.to_h
    231:   return true if @validation.success?
 => 232:   require 'pry'; binding.pry
    233:   raise Aliquot::ValidationError, "validation error(s), #{errors_formatted}"
    234: end

[1] pry(#<Aliquot::Validator::EncryptedMessageValidator>)> errors.to_h
=> {:paymentMethodDetails=>{:bar1=>["is missing"], :bar2=>["is missing"]}, :foo1=>["is missing"], :foo2=>["is missing"]}
[2] pry(#<Aliquot::Validator::EncryptedMessageValidator>)> errors_formatted
NoMethodError: undefined method `flat_map' for nil:NilClass
from /var/lib/gems/2.7.0/gems/aliquot-2.1.4/lib/aliquot/validator.rb:249:in `errors_formatted'
```

```ruby
From: /var/lib/gems/2.7.0/gems/aliquot-2.1.4/lib/aliquot/validator.rb:248 Aliquot::Validator::InstanceMethods#errors_formatted:

    247: def errors_formatted(node = [errors])
 => 248:   require 'pry'; binding.pry
    249:   node.pop.flat_map do |key, value|
    250:     if value.is_a?(Array)
    251:       value.map { |error| "#{(node + [key]).join('.')} #{error}" }
    252:     else
    253:       errors_formatted(node + [key, value])
    254:     end
    255:   end
    256: end

[1] pry(#<Aliquot::Validator::EncryptedMessageValidator>)> node
=> [#<Dry::Validation::MessageSet messages=[
  #<Dry::Schema::Message text="is missing" path=[:paymentMethodDetails, :bar1] predicate=:key? input={...}>,
  #<Dry::Schema::Message text="is missing" path=[:paymentMethodDetails, :bar2] predicate=:key? input={...}>,
  #<Dry::Schema::Message text="is missing" path=[:foo1] predicate=:key? input={...}>,
  #<Dry::Schema::Message text="is missing" path=[:foo2] predicate=:key? input={...}>
] options={}>]

[2] pry(#<Aliquot::Validator::EncryptedMessageValidator>)> popped = node.pop
=> #<Dry::Validation::MessageSet messages=[...] options={}>

[3] pry(#<Aliquot::Validator::EncryptedMessageValidator>)> popped.flat_map { |key, value| [key.class, value.class] }
=> [Dry::Schema::Message, NilClass, Dry::Schema::Message, NilClass, Dry::Schema::Message, NilClass, Dry::Schema::Message, NilClass]

[4] pry(#<Aliquot::Validator::EncryptedMessageValidator>)> popped.map { |key, value| [key.class, value.class] }.uniq
=> [[Dry::Schema::Message, NilClass]]
```

Notice that `value` in `Dry::Validation::MessageSet#flat_map { |key, value| ... }` (and similar for `#map`) is always `nil`. Because of this we eventually end up calling `#flat_map` on `nil`.

Now:

```ruby
From: /var/lib/gems/2.7.0/gems/aliquot-2.1.4/lib/aliquot/validator.rb:232 Aliquot::Validator::InstanceMethods#validate:

    228: def validate
    229:   @validation ||= @schema.call(@input)
    230:   @output = @validation.to_h
    231:   return true if @validation.success?
 => 232:   require 'pry'; binding.pry
    233:   raise Aliquot::ValidationError, "validation error(s): #{error_list.join(', ')}"
    234: end

[1] pry(#<Aliquot::Validator::EncryptedMessageValidator>)> raise Aliquot::ValidationError, "validation error(s): #{error_list.join(', ')}"
Aliquot::ValidationError: validation error(s): paymentMethodDetails.bar1 is missing, paymentMethodDetails.bar2 is missing, foo1 is missing, foo2 is missing
```

Tested with:

* Ruby 2.7.4p191 (in Debian Bullseye) and Aliquot 2.1.4
* Ruby 3.1.2p20 (in Debian Bookworm) and Aliquot 2.3.0