### PR TITLE
Fix validation for tokenized ECv1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
 source 'https://rubygems.org'
 
+gem 'aliquot-pay', :git => 'https://github.com/clearhaus/aliquot-pay', :branch => 'make-tokens-consistent-with-googles-sample-tokens'
+
 gemspec

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,3 @@
 source 'https://rubygems.org'
 
-gem 'aliquot-pay', :git => 'https://github.com/clearhaus/aliquot-pay', :branch => 'make-tokens-consistent-with-googles-sample-tokens'
-
 gemspec

--- a/aliquot.gemspec
+++ b/aliquot.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'excon',          '~> 0.71.0'
   s.add_runtime_dependency 'hkdf',           '~> 0.3'
 
-  s.add_development_dependency 'aliquot-pay', '~> 3.0'
+  s.add_development_dependency 'aliquot-pay'
   s.add_development_dependency 'rspec',       '~> 3'
   s.add_development_dependency 'pry',         '~> 0.14.1'
 end

--- a/aliquot.gemspec
+++ b/aliquot.gemspec
@@ -3,7 +3,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |s|
   s.name     = 'aliquot'
-  s.version  = '2.3.1'
+  s.version  = '3.0.0'
   s.author   = 'Clearhaus'
   s.email    = 'hello@clearhaus.com'
   s.summary  = 'Validates Google Pay tokens'
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'excon',          '~> 0.71.0'
   s.add_runtime_dependency 'hkdf',           '~> 0.3'
 
-  s.add_development_dependency 'aliquot-pay'
+  s.add_development_dependency 'aliquot-pay', '~> 4.0'
   s.add_development_dependency 'rspec',       '~> 3'
   s.add_development_dependency 'pry',         '~> 0.14.1'
 end

--- a/lib/aliquot/payment.rb
+++ b/lib/aliquot/payment.rb
@@ -66,6 +66,8 @@ module Aliquot
 
       begin
         @message = JSON.parse(decrypt(aes_key, @signed_message[:encryptedMessage]))
+        @message.merge!('threedsCryptogram' => @message.delete('3dsCryptogram')) if @message['3dsCryptogram']
+        @message
       rescue JSON::JSONError => e
         raise InputError, "encryptedMessage JSON is invalid, #{e.message}"
       rescue => e

--- a/lib/aliquot/payment.rb
+++ b/lib/aliquot/payment.rb
@@ -66,9 +66,9 @@ module Aliquot
 
       begin
         @message = JSON.parse(decrypt(aes_key, @signed_message[:encryptedMessage]))
-
-        @message["paymentMethodDetails"].transform_keys!('3dsCryptogram' => 'threedsCryptogram' ) if
-          @message['paymentMethodDetails']['3dsCryptogram']
+        @message["paymentMethodDetails"].merge!(
+          'threedsCryptogram' => @message["paymentMethodDetails"]
+          .delete('3dsCryptogram')) if @message["paymentMethodDetails"]['3dsCryptogram']
       rescue JSON::JSONError => e
         raise InputError, "encryptedMessage JSON is invalid, #{e.message}"
       rescue => e

--- a/lib/aliquot/payment.rb
+++ b/lib/aliquot/payment.rb
@@ -66,15 +66,14 @@ module Aliquot
 
       begin
         @message = JSON.parse(decrypt(aes_key, @signed_message[:encryptedMessage]))
-        @message["paymentMethodDetails"].merge!(
-          'threedsCryptogram' => @message["paymentMethodDetails"]
-          .delete('3dsCryptogram')) if @message["paymentMethodDetails"]['3dsCryptogram']
+        @message['paymentMethodDetails'].merge!(
+          'threedsCryptogram' => @message['paymentMethodDetails']
+          .delete('3dsCryptogram')) if @message['paymentMethodDetails']['3dsCryptogram']
       rescue JSON::JSONError => e
         raise InputError, "encryptedMessage JSON is invalid, #{e.message}"
       rescue => e
         raise DecryptionError, "decryption failed, #{e.message}"
       end
-
 
       @message = validate_message
 

--- a/lib/aliquot/validator.rb
+++ b/lib/aliquot/validator.rb
@@ -240,8 +240,8 @@ module Aliquot
       end
 
       rule(:paymentMethod) do
-        if values[:paymentMethodDetails] && values[:paymentMethodDetails].is_a?(Hash)
-          if '3DS'.eql?(values[:paymentMethodDetails] && values[:paymentMethodDetails]['authMethod']) # Tokenized ECv1
+        if values[:paymentMethodDetails].is_a?(Hash)
+          if '3DS'.eql?(values[:paymentMethodDetails]['authMethod']) # Tokenized ECv1
             key.failure('must be equal to TOKENIZED_CARD') unless value == 'TOKENIZED_CARD'
           else
             key.failure('must be equal to CARD') unless value == 'CARD'

--- a/lib/aliquot/validator.rb
+++ b/lib/aliquot/validator.rb
@@ -143,7 +143,7 @@ module Aliquot
       rule(:signedMessage).validate(:json?)
 
       rule(:intermediateSigningKey) do
-        key.failure('is missing') if 'ECv2'.eql?(values[:protocolVersion]) &&
+        key.failure('is missing') if values[:protocolVersion] == 'ECv2' &&
                                      values[:intermediateSigningKey].nil?
       end
     end
@@ -224,28 +224,26 @@ module Aliquot
       rule(:messageExpiration).validate(:integer_string?)
 
       rule(:paymentMethodDetails).validate do
-        contract = nil
-        if 'ECv1'.eql?(values[:protocolVersion])
-          if 'TOKENIZED_CARD'.eql?(values[:paymentMethod])
-            contract = ECv1_TokenizedPaymentMethodDetailsContract.new
+        if values[:protocolVersion] == 'ECv1'
+          if values[:paymentMethod] == 'TOKENIZED_CARD'
+            return ECv1_TokenizedPaymentMethodDetailsContract.new
           else
-            contract = ECv1_PaymentMethodDetailsContract.new
+            return ECv1_PaymentMethodDetailsContract.new
           end
         else
-          if 'CRYPTOGRAM_3DS'.eql?(values[:authMethod])
-            contract = ECv2_TokenizedPaymentMethodDetailsContract.new
+          if  values[:authMethod] == 'CRYPTOGRAM_3DS'
+            return ECv2_TokenizedPaymentMethodDetailsContract.new
           else
-            contract = ECv2_PaymentMethodDetailsContract.new
+            return ECv2_PaymentMethodDetailsContract.new
           end
         end
-        contract
       end
       rule(:paymentMethod) do
         if values[:paymentMethodDetails] && values[:paymentMethodDetails].is_a?(Hash)
           if '3DS'.eql?(values[:paymentMethodDetails] && values[:paymentMethodDetails]['authMethod']) # Tokenized ECv1
-            key.failure('must be equal to TOKENIZED_CARD') unless 'TOKENIZED_CARD'.eql?(value)
+            key.failure('must be equal to TOKENIZED_CARD') unless value == 'TOKENIZED_CARD'
           else
-            key.failure('must be equal to CARD') unless 'CARD'.eql?(value)
+            key.failure('must be equal to CARD') unless value == 'CARD'
           end
         end
       end

--- a/lib/aliquot/validator.rb
+++ b/lib/aliquot/validator.rb
@@ -229,7 +229,7 @@ module Aliquot
           if 'TOKENIZED_CARD'.eql?(values[:paymentMethod])
             contract = ECv1_TokenizedPaymentMethodDetailsContract.new
           else
-            contract =  ECv1_PaymentMethodDetailsContract.new
+            contract = ECv1_PaymentMethodDetailsContract.new
           end
         else
           if 'CRYPTOGRAM_3DS'.eql?(values[:authMethod])

--- a/spec/expectations/schema.rb
+++ b/spec/expectations/schema.rb
@@ -29,12 +29,20 @@ RSpec::Matchers.define :dissatisfy_schema do |expected, mismatches|
 
     return false unless @errors.keys.include? mismatches.keys.first
 
+    @errors.keys.each do |error|
+      return false unless mismatches.keys.include? error
+    end
+
     @errors.values.each do |error|
       return false unless mismatches.values.include? error
     end
 
     mismatches.values.each do |mismatch|
       return false unless @errors.values.include? mismatch
+    end
+
+    mismatches.keys.each do |mismatch|
+      return false unless @errors.keys.include? mismatch
     end
 
     true

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -47,13 +47,13 @@ describe Aliquot::Payment do
   end
 
   context :ECv1 do
-    let (:generator) { AliquotPay.new(:ECv1) }
+    let (:generator) { AliquotPay.new(protocol_version: :ECv1, type: :browser) }
 
     include_examples 'common integration tests'
   end
 
   context :ECv2 do
-    let (:generator) { AliquotPay.new(:ECv2) }
+    let (:generator) { AliquotPay.new(protocol_version: :ECv2, type: :browser) }
 
     include_examples 'common integration tests'
 

--- a/spec/lib/aliquot/payment_spec.rb
+++ b/spec/lib/aliquot/payment_spec.rb
@@ -98,7 +98,6 @@ shared_examples 'only ECv2' do
 end
 
 describe Aliquot::Payment do
-  let(:generator) { AliquotPay.new(protocol_version: :ECv1, type: :browser) }
   subject do
     -> do Aliquot::Payment.new(generator.token.to_json,
                                generator.shared_secret,
@@ -111,22 +110,23 @@ describe Aliquot::Payment do
   context 'ECv1' do
     context 'non-tokenized' do
       let(:generator) { AliquotPay.new(protocol_version: :ECv1, type: :browser) }
-      let(:token) { generator.token }
 
       include_examples 'all protocol versions'
+
       it 'decrypts with PAN_ONLY' do
         expect { subject.call }.to_not raise_error
-        expect(subject.call[:paymentMethodDetails]).to_not include('authMethod' => 'PAN_ONLY')
+        expect(subject.call[:paymentMethodDetails]).to_not include(:authMethod => 'PAN_ONLY')
       end
     end
+
     context 'tokenized' do
       let(:generator) { AliquotPay.new(protocol_version: :ECv1, type: :app) }
-      let(:token) { generator.token }
 
       include_examples 'all protocol versions'
+
       it 'decrypts with 3DS' do
         expect { subject.call }.to_not raise_error
-        expect(subject.call[:paymentMethodDetails]).to include('authMethod' => '3DS')
+        expect(subject.call[:paymentMethodDetails]).to include(:authMethod => '3DS')
       end
     end
   end
@@ -138,20 +138,23 @@ describe Aliquot::Payment do
 
       include_examples 'all protocol versions'
       include_examples 'only ECv2'
+
       it 'decrypts' do
         expect { subject.call }.to_not raise_error
-        expect(subject.call[:paymentMethodDetails]).to include('authMethod' => 'PAN_ONLY')
+        expect(subject.call[:paymentMethodDetails]).to include(:authMethod => 'PAN_ONLY')
       end
     end
+
     context 'tokenized' do
       let(:generator) { AliquotPay.new(protocol_version: :ECv2, type: :app) }
       let(:token) { generator.token }
 
       include_examples 'all protocol versions'
       include_examples 'only ECv2'
+
       it 'decrypts' do
         expect { subject.call }.to_not raise_error
-        expect(subject.call[:paymentMethodDetails]).to include('authMethod' => 'CRYPTOGRAM_3DS')
+        expect(subject.call[:paymentMethodDetails]).to include(:authMethod => 'CRYPTOGRAM_3DS')
       end
     end
   end

--- a/spec/lib/aliquot/payment_spec.rb
+++ b/spec/lib/aliquot/payment_spec.rb
@@ -29,8 +29,8 @@ shared_examples 'all protocol versions' do
   #     see https://clearhaus.slack.com/archives/C3LG75WE9/p1661940442665459
   it 'rejects invalid encryptedMessage JSON gracefully'
 
-  # KSE: Can this be triggered?
-  it 'fails decryption gracefully'
+  # # KSE: Can this be triggered?
+  # it 'fails decryption gracefully'
 
   it 'rejects expired token' do
     generator.message_expiration = (Time.now.to_f - 20).round.to_s

--- a/spec/lib/aliquot/validator_spec.rb
+++ b/spec/lib/aliquot/validator_spec.rb
@@ -243,10 +243,9 @@ shared_examples 'Validator Spec' do
 end
 
 shared_examples 'ECv2 PaymentMethodDetails' do
-
   context 'IntermediateSigningKeySchema' do
     let(:schema) { Aliquot::Validator::IntermediateSigningKeyContract.new }
-    let(:key)  { token['intermediateSigningKey'] }
+    let(:key)    { token['intermediateSigningKey'] }
     subject do
       key
     end
@@ -272,7 +271,6 @@ shared_examples 'ECv2 PaymentMethodDetails' do
       it 'must be valid json'
 
       it 'must pass' do
-
         expect(JSON.parse(key.to_json, symbolize_names: false)).to satisfy_schema(schema)
       end
     end
@@ -476,13 +474,15 @@ describe Aliquot::Validator do
       token
     end
     describe 'non-tokenized' do
-      let(:schema) { Aliquot::Validator::ECv1_PaymentMethodDetailsContract.new }
       let(:generator) { AliquotPay.new(protocol_version: :ECv1, type: :browser) }
       let(:token)     { generator.token }
       include_examples 'Validator Spec'
 
       context 'pan' do
+        let(:schema) { Aliquot::Validator::ECv1_PaymentMethodDetailsContract.new }
+        let(:token)  { generator.build_cleartext_message['paymentMethodDetails'] }
         it 'must exist' do
+          token.merge!('threedsCryptogram' => token.delete('3dsCryptogram'))
           token.delete('pan')
           is_expected.to dissatisfy_schema(schema, {pan: ['is missing']})
         end
@@ -509,13 +509,15 @@ describe Aliquot::Validator do
     end
 
     describe 'tokenized' do
-      let(:schema) { Aliquot::Validator::ECv1_TokenizedPaymentMethodDetailsContract.new }
       let(:generator) { AliquotPay.new(protocol_version: :ECv1, type: :app) }
       let(:token)     { generator.token }
       include_examples 'Validator Spec'
 
       context 'dpan' do
+        let(:schema) { Aliquot::Validator::ECv1_TokenizedPaymentMethodDetailsContract.new }
+        let(:token)  { generator.build_cleartext_message['paymentMethodDetails'] }
         it 'must exist' do
+          token.merge!('threedsCryptogram' => token.delete('3dsCryptogram'))
           token.delete('dpan')
           is_expected.to dissatisfy_schema(schema, {dpan: ['is missing']})
         end
@@ -534,11 +536,10 @@ describe Aliquot::Validator do
 
       context 'intermediateSigningKey' do
         let(:schema) { Aliquot::Validator::TokenContract.new }
-        let(:input)  { token }
 
         it 'should not be enforced' do
           token.delete('intermediateSigningKey')
-          expect(JSON.parse(input.to_json, symbolize_names: false)).to satisfy_schema(schema)
+          expect(JSON.parse(token.to_json, symbolize_names: false)).to satisfy_schema(schema)
         end
       end
     end
@@ -549,14 +550,16 @@ describe Aliquot::Validator do
       token
     end
     context 'non-tokenized' do
-      let(:schema) { Aliquot::Validator::ECv2_PaymentMethodDetailsContract.new }
       let(:generator) { AliquotPay.new(protocol_version: :ECv2, type: :browser) }
       let(:token)     { generator.token }
       include_examples 'Validator Spec'
       include_examples 'ECv2 PaymentMethodDetails'
 
       context 'pan' do
+        let(:schema) { Aliquot::Validator::ECv2_PaymentMethodDetailsContract.new }
+        let(:token)  { generator.build_cleartext_message['paymentMethodDetails'] }
         it 'must exist' do
+          token.merge!('threedsCryptogram' => token.delete('3dsCryptogram'))
           token.delete('pan')
           is_expected.to dissatisfy_schema(schema, {pan: ['is missing']})
         end
@@ -572,16 +575,17 @@ describe Aliquot::Validator do
       end
     end
 
-
     context 'tokenized' do
-      let(:schema) { Aliquot::Validator::ECv2_TokenizedPaymentMethodDetailsContract.new }
-      let(:generator) { AliquotPay.new(protocol_version: :ECv2, type: :browser) }
+      let(:generator) { AliquotPay.new(protocol_version: :ECv2, type: :app) }
       let(:token)     { generator.token }
       include_examples 'Validator Spec'
       include_examples 'ECv2 PaymentMethodDetails'
 
       context 'pan' do
+        let(:schema) { Aliquot::Validator::ECv2_TokenizedPaymentMethodDetailsContract.new }
+        let(:token)  { generator.build_cleartext_message['paymentMethodDetails'] }
         it 'must exist' do
+          token.merge!('threedsCryptogram' => token.delete('3dsCryptogram'))
           token.delete('pan')
           is_expected.to dissatisfy_schema(schema, {pan: ['is missing']})
         end

--- a/spec/lib/aliquot/validator_spec.rb
+++ b/spec/lib/aliquot/validator_spec.rb
@@ -577,7 +577,7 @@ describe Aliquot::Validator do
       let(:schema) { Aliquot::Validator::ECv2_TokenizedPaymentMethodDetailsContract.new }
       let(:generator) { AliquotPay.new(protocol_version: :ECv2, type: :browser) }
       let(:token)     { generator.token }
-      # include_examples 'Validator Spec'
+      include_examples 'Validator Spec'
       include_examples 'ECv2 PaymentMethodDetails'
 
       context 'pan' do


### PR DESCRIPTION
Start supporting validation of tokenized ECv1 tokens. Previously they have not been supported.